### PR TITLE
Use nwjsBuilder manifest props in darwin build.

### DIFF
--- a/src/lib/build/darwin.js
+++ b/src/lib/build/darwin.js
@@ -246,6 +246,22 @@ const BuildDarwinBinary = (path, binaryDir, version, platform, arch, {
             pl['CFBundleShortVersionString'] = this.manifest.version;
             pl['CFBundleIdentifier'] = 'io.nwjs-builder.' + this.manifest.name.toLowerCase();
 
+            if(this.manifest.nwjsBuilder) {
+
+                const properties = this.manifest.nwjsBuilder;
+
+                if(properties.productName) {
+                    pl['CFBundleDisplayName'] = properties.productName;
+                    pl['CFBundleName'] = properties.productName;
+                }
+
+                if(properties.productVersion) {
+                    pl['CFBundleVersion'] = properties.productVersion;
+                    pl['CFBundleShortVersionString'] = properties.productVersion;
+                }
+
+            }
+
             err = yield writeFile(infoFile, plist.build(pl), cb.single);
 
             if(err) {


### PR DESCRIPTION
This only uses nwjsBuilder.productName and nwjsBuilder.productVersion
since those are the only properties pertinent to plist.build options
used.