### PR TITLE
Add CFBundlerIdentifier to darwin manifest support

### DIFF
--- a/src/lib/build/darwin.js
+++ b/src/lib/build/darwin.js
@@ -253,6 +253,7 @@ const BuildDarwinBinary = (path, binaryDir, version, platform, arch, {
                 if(properties.productName) {
                     pl['CFBundleDisplayName'] = properties.productName;
                     pl['CFBundleName'] = properties.productName;
+                    pl['CFBundleIdentifier'] = 'io.nwjs-builder.' + properties.productName.toLowerCase();
                 }
 
                 if(properties.productVersion) {


### PR DESCRIPTION
I somehow missed this earlier. It makes sense to use the `nwjsBuilder.productName` for darwin plist field `CFBundleIdentifier`.